### PR TITLE
Improve path detection

### DIFF
--- a/plugin/install.vim
+++ b/plugin/install.vim
@@ -1,23 +1,25 @@
 com! -nargs=1 -complete=dir DeployEclimd call s:deploy_eclimd(<f-args>)
 
 function! s:deploy_eclimd(eclipsePath)
-    let l:eclim_d = '/tmp/eclim'
-    let l:eclipse_d = resolve(getcwd() . '/' . a:eclipsePath)
-    let l:vim_d = '/tmp/vim-eclim'
+  let l:eclim_d = '/tmp/eclim'
+  let l:eclipse_d = resolve(getcwd() . '/' . a:eclipsePath)
+  let l:vim_d = '/tmp/vim-eclim'
 
-    if ! filereadable(l:eclipse_d . '/eclipse.ini')
-        echom 'Eclipse path invalid.'
-        return
-    endif
+  if ! filereadable(l:eclipse_d . '/eclipse.ini')
+    echom 'Eclipse path invalid.'
+    return
+  endif
 
-    " download code, build and then remove
-    execute 'silent !git clone https://github.com/ervandew/eclim.git ' . l:eclim_d
-    execute 'cd ' . l:eclim_d
+  " download code, build and then remove
+  execute 'silent !git clone https://github.com/ervandew/eclim.git ' . l:eclim_d
+  execute 'cd ' . l:eclim_d
 
-    " always checkout last release to build from
-    let l:last_tag = split(system('git tag'), '\n')[-1]
-    execute 'silent !git checkout ' . l:last_tag
-    execute 'silent !ant -Dvim.files=' . l:vim_d ' -Declipse.home=' . l:eclipse_d
-    execute 'cd -'
-    execute 'silent !rm -rf ' . l:eclim_d . ' ' . l:vim_d
+  " always checkout last release to build from
+  let l:last_tag = split(system('git tag'), '\n')[-1]
+  execute 'silent !git checkout ' . l:last_tag
+  execute 'silent !ant -Dvim.files=' . l:vim_d ' -Declipse.home=' . l:eclipse_d
+  execute 'cd -'
+  execute 'silent !rm -rf ' . l:eclim_d . ' ' . l:vim_d
 endfunction
+
+" vim: sw=2 ts=2 sts=2

--- a/plugin/install.vim
+++ b/plugin/install.vim
@@ -5,8 +5,8 @@ function! s:deploy_eclimd(eclipsePath)
   let l:eclipse_d = resolve(getcwd() . '/' . a:eclipsePath)
   let l:vim_d = '/tmp/vim-eclim'
 
-  if ! executable('git')
-    echom 'Please install git first.'
+  if ! executable('git') || ! executable('ant')
+    echom 'Please make sure you have git and ant installed.'
     return
   endif
 

--- a/plugin/install.vim
+++ b/plugin/install.vim
@@ -5,6 +5,11 @@ function! s:deploy_eclimd(eclipsePath)
   let l:eclipse_d = resolve(getcwd() . '/' . a:eclipsePath)
   let l:vim_d = '/tmp/vim-eclim'
 
+  if ! executable('git')
+    echom 'Please install git first.'
+    return
+  endif
+
   if ! filereadable(l:eclipse_d . '/eclipse.ini')
     echom 'Eclipse path invalid.'
     return

--- a/plugin/install.vim
+++ b/plugin/install.vim
@@ -13,6 +13,7 @@ function! s:deploy_eclimd(eclipsePath)
   if ! filereadable(l:eclipse_d . '/eclipse.ini') &&
         \ ! filereadable(expand(a:eclipsePath) . '/eclipse.ini')
     echom 'Eclipse path invalid.'
+    echom 'Please specify the directory that contains eclipse.ini.'
     return
   endif
 

--- a/plugin/install.vim
+++ b/plugin/install.vim
@@ -10,7 +10,8 @@ function! s:deploy_eclimd(eclipsePath)
     return
   endif
 
-  if ! filereadable(l:eclipse_d . '/eclipse.ini')
+  if ! filereadable(l:eclipse_d . '/eclipse.ini') &&
+        \ ! filereadable(expand(a:eclipsePath) . '/eclipse.ini')
     echom 'Eclipse path invalid.'
     return
   endif


### PR DESCRIPTION
Hello, thanks for hosting a repository that makes it easier to install eclim with a package manager.

I personally found it really confusing that you need to specify the relative path to `eclipse.ini`, so I made this change so that an absolute path can also be given. There are some other changes that I thought would make more sense, but feel free to cherry-pick if you don't like any of them.

Thanks!
